### PR TITLE
Feat/tests setup

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,23 @@
+name: CI - Tests
+
+on:
+  push:
+    branches:
+      - feat/tests-setup
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Temurin JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run tests
+        run: mvn -B -e -V -DskipITs -DskipIT -Dskip-integration-tests test
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ feat/tests-setup ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Run tests with coverage (JaCoCo)
+        run: mvn -B -q test
+
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
+
+  require-tests:
+    if: github.event_name == 'pull_request'
+    needs: [ build-and-test ]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All tests passed; PR can be merged."
+

--- a/.github/workflows/create-testing-issue.yml
+++ b/.github/workflows/create-testing-issue.yml
@@ -1,0 +1,61 @@
+name: Create testing issue
+
+on:
+  push:
+    branches:
+      - feat/tests-setup
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or verify testing issue
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          title="Add testing infrastructure for plugin"
+          body="Set up test framework, coverage reporting, CI job, and example tests for the plugin. Deliverables: configured test runner, initial unit/integration tests, coverage threshold, CI workflow, and developer docs (README)."
+
+          echo "Checking for existing issue titled: $title"
+          existing=$(curl -sS -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GH_REPO}/issues?state=open&per_page=100")
+
+          if echo "$existing" | grep -F '"title": "' | grep -F "$title" >/dev/null; then
+            echo "Issue already exists. Skipping creation."
+            exit 0
+          fi
+
+          echo "Creating new issue..."
+          payload=$(cat <<'JSON'
+          {
+            "title": "Add testing infrastructure for plugin",
+            "body": "Set up test framework, coverage reporting, CI job, and example tests for the plugin. Deliverables: configured test runner, initial unit/integration tests, coverage threshold, CI workflow, and developer docs (README).",
+            "labels": ["testing", "enhancement"]
+          }
+          JSON
+          )
+
+          http_code=$(printf "%s" "$payload" | curl -sS -o /tmp/issue_resp.json -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GH_REPO}/issues" \
+            -d @-)
+
+          echo "HTTP: ${http_code}"
+          if [ "$http_code" != "201" ]; then
+            echo "Response:"
+            head -n 200 /tmp/issue_resp.json
+            exit 1
+          fi
+
+          url=$(sed -n 's/.*"html_url": "\([^"]*\)".*/\1/p' /tmp/issue_resp.json | head -n 1)
+          echo "Created: ${url}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ target/
 .vscode/
 *.iml
 
+# Local editor metadata
+.cursor/
+
 # OS/Java
 .DS_Store
 *.class

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,37 @@
       <version>1.7</version>
       <scope>provided</scope>
     </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>5.2.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockbukkit.mockbukkit</groupId>
+      <artifactId>mockbukkit-v1.21</artifactId>
+      <version>4.0.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -66,6 +97,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
       </plugin>
     </plugins>
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21.4-R0.1-SNAPSHOT</version>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.mockbukkit.mockbukkit</groupId>
       <artifactId>mockbukkit-v1.21</artifactId>
-      <version>4.0.0</version>
+      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -105,6 +105,51 @@
         <configuration>
           <useModulePath>false</useModulePath>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.11</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>1.0</minimum>
+                    </limit>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>1.0</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <resources>

--- a/src/main/java/com/tnauctionhouse/TNAuctionHousePlugin.java
+++ b/src/main/java/com/tnauctionhouse/TNAuctionHousePlugin.java
@@ -12,7 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public final class TNAuctionHousePlugin extends JavaPlugin {
+public class TNAuctionHousePlugin extends JavaPlugin {
 
     private static TNAuctionHousePlugin instance;
     private Economy economy;

--- a/src/main/java/com/tnauctionhouse/commands/SellOrderCreateCommand.java
+++ b/src/main/java/com/tnauctionhouse/commands/SellOrderCreateCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
 
 public class SellOrderCreateCommand implements CommandExecutor {
 
@@ -30,7 +31,7 @@ public class SellOrderCreateCommand implements CommandExecutor {
         }
 
         ItemStack hand = player.getInventory().getItemInMainHand();
-        if (hand == null || hand.getType().isAir()) {
+        if (hand == null || isAirMaterial(hand.getType())) {
             player.sendMessage("Hold an item to sell.");
             return true;
         }
@@ -109,6 +110,13 @@ public class SellOrderCreateCommand implements CommandExecutor {
 
 		player.sendMessage("Created sell order: " + amount + "x for $" + pricePerUnitEffective + " each.");
         return true;
+    }
+
+    private boolean isAirMaterial(Material material) {
+        if (material == null) {
+            return true;
+        }
+        return material == Material.AIR || material == Material.CAVE_AIR || material == Material.VOID_AIR;
     }
 }
 

--- a/src/test/java/com/tnauctionhouse/TNAuctionHousePluginLifecycleTest.java
+++ b/src/test/java/com/tnauctionhouse/TNAuctionHousePluginLifecycleTest.java
@@ -1,0 +1,109 @@
+package com.tnauctionhouse;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.ServicePriority;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TNAuctionHousePluginLifecycleTest {
+
+    private ServerMock server;
+
+    @BeforeEach
+    void setup() {
+        server = MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testOnEnableWithoutVaultDisablesPlugin() {
+        TNAuctionHousePlugin plugin = MockBukkit.load(TNAuctionHousePlugin.class);
+        assertFalse(plugin.isEnabled(), "Plugin should be disabled if Vault is missing");
+    }
+
+    @Test
+    void testOnEnableWithVaultRegistersManagersAndCommands() {
+        // Create a mock Vault plugin and register a dummy Economy provider
+        Plugin vault = MockBukkit.createMockPlugin("Vault");
+        Economy dummy = new DummyEconomy();
+        server.getServicesManager().register(Economy.class, dummy, vault, ServicePriority.Normal);
+
+        TNAuctionHousePlugin plugin = MockBukkit.load(TNAuctionHousePlugin.class);
+        assertTrue(plugin.isEnabled());
+        assertNotNull(plugin.getEconomy());
+        assertNotNull(plugin.getOrderManager());
+        assertNotNull(plugin.getOrderLogger());
+        assertNotNull(plugin.getNotificationManager());
+
+        // Commands should be registered
+        assertNotNull(server.getCommandMap().getCommand("sellorder"));
+        assertNotNull(server.getCommandMap().getCommand("buyorder"));
+        assertNotNull(server.getCommandMap().getCommand("sellorders"));
+        assertNotNull(server.getCommandMap().getCommand("buyorders"));
+        assertNotNull(server.getCommandMap().getCommand("withdrawitems"));
+        assertNotNull(server.getCommandMap().getCommand("auctionhouse"));
+        assertNotNull(server.getCommandMap().getCommand("myorders"));
+    }
+
+    // Minimal Economy stub sufficient for plugin boot and simple has/withdraw/deposit used in code
+    static class DummyEconomy implements Economy {
+        @Override public boolean isEnabled() { return true; }
+        @Override public String getName() { return "dummy"; }
+        @Override public boolean hasBankSupport() { return false; }
+        @Override public int fractionalDigits() { return 0; }
+        @Override public String format(double amount) { return String.valueOf((int) amount); }
+        @Override public String currencyNamePlural() { return "dollars"; }
+        @Override public String currencyNameSingular() { return "dollar"; }
+        @Override public boolean hasAccount(String playerName) { return true; }
+        @Override public boolean hasAccount(org.bukkit.OfflinePlayer player) { return true; }
+        @Override public boolean hasAccount(String playerName, String worldName) { return true; }
+        @Override public boolean hasAccount(org.bukkit.OfflinePlayer player, String worldName) { return true; }
+        @Override public EconomyResponse withdrawPlayer(org.bukkit.OfflinePlayer player, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse depositPlayer(org.bukkit.OfflinePlayer player, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public boolean has(String playerName, double amount) { return true; }
+        @Override public boolean has(org.bukkit.OfflinePlayer player, double amount) { return true; }
+        @Override public boolean has(String playerName, String worldName, double amount) { return true; }
+        @Override public boolean has(org.bukkit.OfflinePlayer player, String worldName, double amount) { return true; }
+        @Override public EconomyResponse withdrawPlayer(String playerName, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse withdrawPlayer(String playerName, String worldName, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse withdrawPlayer(org.bukkit.OfflinePlayer player, String worldName, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse depositPlayer(String playerName, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse depositPlayer(String playerName, String worldName, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse depositPlayer(org.bukkit.OfflinePlayer player, String worldName, double amount) { return new EconomyResponse(amount, 0, EconomyResponse.ResponseType.SUCCESS, ""); }
+        @Override public EconomyResponse createBank(String name, String player) { return notSupported(); }
+        @Override public EconomyResponse createBank(String name, org.bukkit.OfflinePlayer player) { return notSupported(); }
+        @Override public EconomyResponse deleteBank(String name) { return notSupported(); }
+        @Override public EconomyResponse bankBalance(String name) { return notSupported(); }
+        @Override public EconomyResponse bankHas(String name, double amount) { return notSupported(); }
+        @Override public EconomyResponse bankWithdraw(String name, double amount) { return notSupported(); }
+        @Override public EconomyResponse bankDeposit(String name, double amount) { return notSupported(); }
+        @Override public EconomyResponse isBankOwner(String name, String playerName) { return notSupported(); }
+        @Override public EconomyResponse isBankOwner(String name, org.bukkit.OfflinePlayer player) { return notSupported(); }
+        @Override public EconomyResponse isBankMember(String name, String playerName) { return notSupported(); }
+        @Override public EconomyResponse isBankMember(String name, org.bukkit.OfflinePlayer player) { return notSupported(); }
+        @Override public java.util.List<String> getBanks() { return java.util.Collections.emptyList(); }
+        @Override public boolean createPlayerAccount(String playerName) { return true; }
+        @Override public boolean createPlayerAccount(org.bukkit.OfflinePlayer player) { return true; }
+        @Override public boolean createPlayerAccount(String playerName, String worldName) { return true; }
+        @Override public boolean createPlayerAccount(org.bukkit.OfflinePlayer player, String worldName) { return true; }
+
+        private EconomyResponse notSupported() { return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, ""); }
+        @Override public double getBalance(String playerName) { return 0; }
+        @Override public double getBalance(org.bukkit.OfflinePlayer player) { return 0; }
+        @Override public double getBalance(String playerName, String world) { return 0; }
+        @Override public double getBalance(org.bukkit.OfflinePlayer player, String world) { return 0; }
+      }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/commands/AuctionHouseCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/AuctionHouseCommandTest.java
@@ -1,0 +1,58 @@
+package com.tnauctionhouse.commands;
+
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AuctionHouseCommandTest {
+
+    private TNAuctionHousePlugin plugin;
+    private AuctionHouseCommand command;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        command = new AuctionHouseCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "auctionhouse", new String[] {});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+    }
+
+    @Test
+    void missingArgsShowsUsage() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        boolean result = command.onCommand(player, null, "auctionhouse", new String[] {});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("Usage: /auctionhouse search <query> [sell|buy]");
+    }
+
+    // Intentionally no GUI-open tests in headless environment
+
+    @Test
+    void unknownSubcommandShowsHelp() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        boolean result = command.onCommand(player, null, "auctionhouse", new String[] {"noop"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("Unknown subcommand. Try: /auctionhouse search <query> [sell|buy]");
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/commands/BuyOrderCreateCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/BuyOrderCreateCommandTest.java
@@ -1,0 +1,142 @@
+package com.tnauctionhouse.commands;
+
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.entity.Player;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class BuyOrderCreateCommandTest {
+
+    private TNAuctionHousePlugin plugin;
+    private BuyOrderCreateCommand command;
+    private YamlConfiguration config;
+    private Economy economy;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        config = new YamlConfiguration();
+        // Defaults
+        config.set("buy_tax.enabled", true);
+        config.set("buy_tax.rate", 0.10);
+        config.set("buy_tax.mode", "UPFRONT");
+        when(plugin.getConfig()).thenReturn(config);
+
+        economy = Mockito.mock(Economy.class);
+        when(plugin.getEconomy()).thenReturn(economy);
+
+        command = new BuyOrderCreateCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "buyorder", new String[] {"10", "2"});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+    }
+
+    @Test
+    void missingPermission() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.buyorder")).thenReturn(false);
+
+        boolean result = command.onCommand(player, null, "buyorder", new String[] {"10", "2"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("You don't have permission.");
+    }
+
+    @Test
+    void emptyHandError() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.buyorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.AIR);
+        when(inv.getItemInMainHand()).thenReturn(hand);
+
+        boolean result = command.onCommand(player, null, "buyorder", new String[] {"10", "2"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("Hold an item to create a buy order for.");
+    }
+
+    @Test
+    void missingArgsShowsUsage() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.buyorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = new ItemStack(Material.DIAMOND, 1);
+        when(inv.getItemInMainHand()).thenReturn(hand);
+
+        boolean result = command.onCommand(player, null, "buyorder", new String[] {"10"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("Usage: /buyorder <price> <amount>");
+    }
+
+    @Test
+    void invalidArgs() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.buyorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = new ItemStack(Material.DIAMOND, 1);
+        when(inv.getItemInMainHand()).thenReturn(hand);
+
+        boolean result = command.onCommand(player, null, "buyorder", new String[] {"foo", "bar"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("Invalid price or amount.");
+    }
+
+    @Test
+    void nonPositiveValues() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.buyorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = new ItemStack(Material.DIAMOND, 1);
+        when(inv.getItemInMainHand()).thenReturn(hand);
+
+        boolean result = command.onCommand(player, null, "buyorder", new String[] {"0", "-1"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("Price and amount must be > 0.");
+    }
+
+    @Test
+    void insufficientFundsWithTax() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.buyorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = new ItemStack(Material.DIAMOND, 1);
+        when(inv.getItemInMainHand()).thenReturn(hand);
+
+        // price=10, amount=2, total=20, fee=2, final=22 -> cannot afford
+        when(economy.has(player, 22)).thenReturn(false);
+
+        boolean result = command.onCommand(player, null, "buyorder", new String[] {"10", "2"});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("You don't have enough money ($22).");
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/commands/OpenBuyOrdersCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/OpenBuyOrdersCommandTest.java
@@ -1,0 +1,51 @@
+package com.tnauctionhouse.commands;
+
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenBuyOrdersCommandTest {
+
+    private TNAuctionHousePlugin plugin;
+    private OpenBuyOrdersCommand command;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        command = new OpenBuyOrdersCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "buyorders", new String[] {});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+    }
+
+    @Test
+    void missingPermission() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(player.hasPermission("tnauctionhouse.buyorders")).thenReturn(false);
+        boolean result = command.onCommand(player, null, "buyorders", new String[] {});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("You don't have permission.");
+    }
+
+    // Intentionally no GUI-open tests in headless environment
+}
+
+

--- a/src/test/java/com/tnauctionhouse/commands/OpenMyOrdersCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/OpenMyOrdersCommandTest.java
@@ -1,0 +1,49 @@
+package com.tnauctionhouse.commands;
+
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenMyOrdersCommandTest {
+
+    private TNAuctionHousePlugin plugin;
+    private OpenMyOrdersCommand command;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        command = new OpenMyOrdersCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "myorders", new String[] {});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+    }
+
+    @Test
+    void missingPermission() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(player.hasPermission("tnauctionhouse.myorders")).thenReturn(false);
+        boolean result = command.onCommand(player, null, "myorders", new String[] {});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("You don't have permission.");
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/commands/OpenSellOrdersCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/OpenSellOrdersCommandTest.java
@@ -1,0 +1,51 @@
+package com.tnauctionhouse.commands;
+
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenSellOrdersCommandTest {
+
+    private TNAuctionHousePlugin plugin;
+    private OpenSellOrdersCommand command;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        command = new OpenSellOrdersCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "sellorders", new String[] {});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+    }
+
+    @Test
+    void missingPermission() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(player.hasPermission("tnauctionhouse.sellorders")).thenReturn(false);
+        boolean result = command.onCommand(player, null, "sellorders", new String[] {});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("You don't have permission.");
+    }
+
+    // Intentionally no GUI-open tests in headless environment
+}
+
+

--- a/src/test/java/com/tnauctionhouse/commands/SellOrderCreateCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/SellOrderCreateCommandTest.java
@@ -1,14 +1,14 @@
 package com.tnauctionhouse.commands;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
-import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
-import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import com.tnauctionhouse.TNAuctionHousePlugin;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.entity.Player;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 public class SellOrderCreateCommandTest {
 
-	private ServerMock server;
     private TNAuctionHousePlugin plugin;
     private SellOrderCreateCommand command;
     private YamlConfiguration config;
@@ -28,8 +27,7 @@ public class SellOrderCreateCommandTest {
 
     @BeforeEach
     void setUp() {
-        server = MockBukkit.mock();
-
+        MockBukkit.mock();
         plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
         config = new YamlConfiguration();
         // Default tax config
@@ -60,99 +58,123 @@ public class SellOrderCreateCommandTest {
 
     @Test
     void missingPermission() {
-        PlayerMock player = server.addPlayer();
-        // Ensure player does NOT have the permission
-        player.setOp(false);
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(false);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"10"});
         assertEquals(true, result);
-        assertEquals("You don't have permission.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("You don't have permission.");
     }
 
     @Test
     void emptyHandError() {
-        PlayerMock player = server.addPlayer();
-        // Give permission
-        player.setOp(true);
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.AIR);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"10"});
         assertEquals(true, result);
-        assertEquals("Hold an item to sell.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("Hold an item to sell.");
     }
 
     @Test
     void missingPriceArgShowsUsage() {
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        // Put an item in hand
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(3);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {});
         assertEquals(true, result);
-        assertEquals("Usage: /sellorder <price> [amount]", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("Usage: /sellorder <price> [amount]");
     }
 
     @Test
     void invalidPrice() {
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(3);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"abc"});
         assertEquals(true, result);
-        assertEquals("Invalid price.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("Invalid price.");
     }
 
     @Test
     void nonPositivePrice() {
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(3);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean resultZero = command.onCommand(player, null, "sellorder", new String[] {"0"});
         assertEquals(true, resultZero);
-        assertEquals("Price must be > 0.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("Price must be > 0.");
     }
 
     @Test
     void invalidAmount() {
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(3);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "foo"});
         assertEquals(true, result);
-        assertEquals("Invalid amount.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("Invalid amount.");
     }
 
     @Test
     void nonPositiveAmount() {
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(3);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "0"});
         assertEquals(true, result);
-        assertEquals("Amount must be > 0.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("Amount must be > 0.");
     }
 
     @Test
     void amountGreaterThanInHand() {
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(3);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "5"});
         assertEquals(true, result);
-        assertEquals("You don't have that many items.", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("You don't have that many items.");
     }
 
     @Test
@@ -162,17 +184,21 @@ public class SellOrderCreateCommandTest {
         config.set("tax.mode", "UPFRONT");
         config.set("tax.rate", 0.10);
 
-        PlayerMock player = server.addPlayer();
-        player.setOp(true);
-        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 1));
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        when(player.hasPermission("tnauctionhouse.sellorder")).thenReturn(true);
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        when(player.getInventory()).thenReturn(inv);
+        ItemStack hand = Mockito.mock(ItemStack.class, Mockito.RETURNS_DEEP_STUBS);
+        when(hand.getType()).thenReturn(Material.DIAMOND);
+        when(hand.getAmount()).thenReturn(1);
+        when(inv.getItemInMainHand()).thenReturn(hand);
 
         // Player cannot afford upfront fee (price=10, amount=1, fee=1.0)
         when(economy.has(player, 1.0)).thenReturn(false);
 
         boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "1"});
         assertEquals(true, result);
-        assertEquals("You don't have enough money to pay the listing fee ($1.0).", player.nextMessage());
-        assertNull(player.nextMessage());
+        Mockito.verify(player).sendMessage("You don't have enough money to pay the listing fee ($1.0).");
     }
 }
 

--- a/src/test/java/com/tnauctionhouse/commands/SellOrderCreateCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/SellOrderCreateCommandTest.java
@@ -1,0 +1,178 @@
+package com.tnauctionhouse.commands;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+public class SellOrderCreateCommandTest {
+
+	private ServerMock server;
+    private TNAuctionHousePlugin plugin;
+    private SellOrderCreateCommand command;
+    private YamlConfiguration config;
+    private Economy economy;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        config = new YamlConfiguration();
+        // Default tax config
+        config.set("tax.enabled", true);
+        config.set("tax.rate", 0.10);
+        config.set("tax.mode", "ADD_TO_PRICE");
+        when(plugin.getConfig()).thenReturn(config);
+
+        economy = Mockito.mock(Economy.class);
+        when(plugin.getEconomy()).thenReturn(economy);
+
+        command = new SellOrderCreateCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "sellorder", new String[] {"10"});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+        assertNull(console.nextMessage());
+    }
+
+    @Test
+    void missingPermission() {
+        PlayerMock player = server.addPlayer();
+        // Ensure player does NOT have the permission
+        player.setOp(false);
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"10"});
+        assertEquals(true, result);
+        assertEquals("You don't have permission.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void emptyHandError() {
+        PlayerMock player = server.addPlayer();
+        // Give permission
+        player.setOp(true);
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"10"});
+        assertEquals(true, result);
+        assertEquals("Hold an item to sell.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void missingPriceArgShowsUsage() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        // Put an item in hand
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {});
+        assertEquals(true, result);
+        assertEquals("Usage: /sellorder <price> [amount]", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void invalidPrice() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"abc"});
+        assertEquals(true, result);
+        assertEquals("Invalid price.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void nonPositivePrice() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+
+        boolean resultZero = command.onCommand(player, null, "sellorder", new String[] {"0"});
+        assertEquals(true, resultZero);
+        assertEquals("Price must be > 0.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void invalidAmount() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "foo"});
+        assertEquals(true, result);
+        assertEquals("Invalid amount.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void nonPositiveAmount() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "0"});
+        assertEquals(true, result);
+        assertEquals("Amount must be > 0.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void amountGreaterThanInHand() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 3));
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "5"});
+        assertEquals(true, result);
+        assertEquals("You don't have that many items.", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+
+    @Test
+    void upfrontTaxInsufficientFunds() {
+        // Configure upfront tax mode
+        config.set("tax.enabled", true);
+        config.set("tax.mode", "UPFRONT");
+        config.set("tax.rate", 0.10);
+
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        player.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND, 1));
+
+        // Player cannot afford upfront fee (price=10, amount=1, fee=1.0)
+        when(economy.has(player, 1.0)).thenReturn(false);
+
+        boolean result = command.onCommand(player, null, "sellorder", new String[] {"10", "1"});
+        assertEquals(true, result);
+        assertEquals("You don't have enough money to pay the listing fee ($1.0).", player.nextMessage());
+        assertNull(player.nextMessage());
+    }
+}
+

--- a/src/test/java/com/tnauctionhouse/commands/WithdrawOrderCommandTest.java
+++ b/src/test/java/com/tnauctionhouse/commands/WithdrawOrderCommandTest.java
@@ -1,0 +1,49 @@
+package com.tnauctionhouse.commands;
+
+import com.tnauctionhouse.TNAuctionHousePlugin;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.command.ConsoleCommandSenderMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WithdrawOrderCommandTest {
+
+    private TNAuctionHousePlugin plugin;
+    private WithdrawOrderCommand command;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = Mockito.mock(TNAuctionHousePlugin.class, Mockito.RETURNS_DEEP_STUBS);
+        command = new WithdrawOrderCommand(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void nonPlayerSenderGetsError() {
+        ConsoleCommandSenderMock console = new ConsoleCommandSenderMock();
+        boolean result = command.onCommand(console, null, "withdrawitems", new String[] {});
+        assertEquals(true, result);
+        assertEquals("Only players can use this command.", console.nextMessage());
+    }
+
+    @Test
+    void missingPermission() {
+        Player player = Mockito.mock(Player.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(player.hasPermission("tnauctionhouse.withdrawitems")).thenReturn(false);
+        boolean result = command.onCommand(player, null, "withdrawitems", new String[] {});
+        assertEquals(true, result);
+        Mockito.verify(player).sendMessage("You don't have permission.");
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/orders/ModelsTest.java
+++ b/src/test/java/com/tnauctionhouse/orders/ModelsTest.java
@@ -1,0 +1,64 @@
+package com.tnauctionhouse.orders;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelsTest {
+
+    @BeforeAll
+    static void bootMockBukkit() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    static void shutdownMockBukkit() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testSellOrderGettersClone() {
+        UUID seller = UUID.randomUUID();
+        org.bukkit.inventory.ItemStack item = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND, 5);
+        SellOrder so = new SellOrder(UUID.randomUUID(), seller, item, 7, 5, 123L);
+        assertEquals(seller, so.getSellerId());
+        assertEquals(7, so.getPricePerUnit());
+        assertEquals(5, so.getAmount());
+        assertEquals(123L, so.getCreatedAt());
+        org.bukkit.inventory.ItemStack a = so.getItem();
+        org.bukkit.inventory.ItemStack b = so.getItem();
+        assertNotSame(a, b);
+        a.setAmount(1);
+        assertEquals(5, so.getItem().getAmount());
+    }
+
+    @Test
+    void testBuyOrderGettersClone() {
+        UUID buyer = UUID.randomUUID();
+        org.bukkit.inventory.ItemStack tpl = new org.bukkit.inventory.ItemStack(org.bukkit.Material.IRON_INGOT, 2);
+        BuyOrder bo = new BuyOrder(UUID.randomUUID(), buyer, tpl, 3, 8, 456L, 24);
+        assertEquals(buyer, bo.getBuyerId());
+        assertEquals(3, bo.getPricePerUnit());
+        assertEquals(8, bo.getAmount());
+        assertEquals(456L, bo.getCreatedAt());
+        assertEquals(24, bo.getEscrowTotal());
+        org.bukkit.inventory.ItemStack a = bo.getTemplateItem();
+        org.bukkit.inventory.ItemStack b = bo.getTemplateItem();
+        assertNotSame(a, b);
+        a.setAmount(64);
+        assertEquals(2, bo.getTemplateItem().getAmount());
+    }
+
+    @Test
+    void testItemTypeCategoryValues() {
+        assertNotNull(ItemTypeCategory.valueOf("WEAPONS"));
+        assertEquals(5, ItemTypeCategory.values().length);
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/orders/OrderManagerDebugWriteTest.java
+++ b/src/test/java/com/tnauctionhouse/orders/OrderManagerDebugWriteTest.java
@@ -1,0 +1,33 @@
+package com.tnauctionhouse.orders;
+
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+public class OrderManagerDebugWriteTest {
+
+    @Test
+    void writeDebugYaml() throws Exception {
+        MockBukkit.mock();
+        try {
+            OrderManager om = new OrderManager();
+            UUID buyer = UUID.randomUUID();
+            om.enqueueDelivery(buyer, new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLD_INGOT, 3));
+            File file = Paths.get("target", "orders-debug.yml").toFile();
+            if (file.exists()) file.delete();
+            om.save(file);
+            System.out.println("WROTE: " + file.getAbsolutePath() + " for buyer=" + buyer);
+
+            OrderManager loaded = new OrderManager();
+            loaded.load(file);
+            System.out.println("LOADED deliveries size: " + loaded.getDeliveries(buyer).size());
+        } finally {
+            MockBukkit.unmock();
+        }
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/orders/OrderManagerRoundtripDebugTest.java
+++ b/src/test/java/com/tnauctionhouse/orders/OrderManagerRoundtripDebugTest.java
@@ -1,0 +1,37 @@
+package com.tnauctionhouse.orders;
+
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+public class OrderManagerRoundtripDebugTest {
+
+    @Test
+    void writeRoundtripYaml() throws Exception {
+        MockBukkit.mock();
+        try {
+            OrderManager om = new OrderManager();
+            UUID seller = UUID.randomUUID();
+            UUID buyer = UUID.randomUUID();
+            om.createSellOrder(seller, new org.bukkit.inventory.ItemStack(org.bukkit.Material.EMERALD, 12), 3, 12);
+            om.createBuyOrder(buyer, new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLD_INGOT, 7), 9, 7, 63);
+            om.enqueueDelivery(buyer, new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLD_INGOT, 3));
+
+            File file = Paths.get("target", "orders-roundtrip.yml").toFile();
+            if (file.exists()) file.delete();
+            om.save(file);
+            System.out.println("WROTE roundtrip: " + file.getAbsolutePath() + " buyer=" + buyer);
+
+            OrderManager loaded = new OrderManager();
+            loaded.load(file);
+            System.out.println("LOADED roundtrip deliveries: " + loaded.getDeliveries(buyer).size());
+        } finally {
+            MockBukkit.unmock();
+        }
+    }
+}
+
+

--- a/src/test/java/com/tnauctionhouse/orders/OrderManagerTest.java
+++ b/src/test/java/com/tnauctionhouse/orders/OrderManagerTest.java
@@ -1,0 +1,197 @@
+package com.tnauctionhouse.orders;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OrderManagerTest {
+
+    @BeforeAll
+    static void bootMockBukkit() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    static void shutdownMockBukkit() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testCreateSellOrderClonesAndStores() {
+        OrderManager om = new OrderManager();
+        org.bukkit.inventory.ItemStack item = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND, 32);
+        int price = 25;
+        int amount = 10;
+
+        SellOrder so = om.createSellOrder(UUID.randomUUID(), item, price, amount);
+
+        assertEquals(1, om.getSellOrders().size());
+        SellOrder stored = om.getSellOrders().get(0);
+        assertEquals(so.getOrderId(), stored.getOrderId());
+        assertEquals(price, stored.getPricePerUnit());
+        assertEquals(amount, stored.getAmount());
+        // ensure clone: modifying returned item does not affect stored
+        org.bukkit.inventory.ItemStack got = stored.getItem();
+        int originalAmount = got.getAmount();
+        got.setAmount(1);
+        assertEquals(originalAmount, stored.getItem().getAmount());
+        // source item unchanged
+        assertEquals(32, item.getAmount());
+    }
+
+    @Test
+    void testCreateBuyOrderTemplateClonedAndStores() {
+        OrderManager om = new OrderManager();
+        org.bukkit.inventory.ItemStack item = new org.bukkit.inventory.ItemStack(org.bukkit.Material.IRON_INGOT, 16);
+        int price = 5;
+        int amount = 12;
+        int escrow = price * amount;
+
+        BuyOrder bo = om.createBuyOrder(UUID.randomUUID(), item, price, amount, escrow);
+
+        assertEquals(1, om.getBuyOrders().size());
+        BuyOrder stored = om.getBuyOrders().get(0);
+        assertEquals(bo.getOrderId(), stored.getOrderId());
+        assertEquals(price, stored.getPricePerUnit());
+        assertEquals(amount, stored.getAmount());
+        assertEquals(1, stored.getTemplateItem().getAmount());
+        // source item unchanged
+        assertEquals(16, item.getAmount());
+    }
+
+    @Test
+    void testPagination() {
+        OrderManager om = new OrderManager();
+        for (int i = 0; i < 100; i++) {
+            om.createSellOrder(UUID.randomUUID(), new org.bukkit.inventory.ItemStack(org.bukkit.Material.STONE, 64), 1, 1);
+        }
+        List<SellOrder> page0 = om.getSellOrdersPage(0, 45);
+        List<SellOrder> page1 = om.getSellOrdersPage(1, 45);
+        List<SellOrder> page2 = om.getSellOrdersPage(2, 45);
+        assertEquals(45, page0.size());
+        assertEquals(45, page1.size());
+        assertEquals(10, page2.size());
+        // negative page coerced to 0
+        assertEquals(page0.size(), om.getSellOrdersPage(-5, 45).size());
+        // out of range page returns empty
+        assertTrue(om.getSellOrdersPage(10, 45).isEmpty());
+    }
+
+    @Test
+    void testSearchByTypeDisplayNameAndLore() {
+        OrderManager om = new OrderManager();
+        // type name contains "diamond_sword"
+        org.bukkit.inventory.ItemStack sword = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND_SWORD, 1);
+        // display name contains "Epic Pick"
+        org.bukkit.inventory.ItemStack pick = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND_PICKAXE, 1);
+        org.bukkit.inventory.meta.ItemMeta pickMeta = pick.getItemMeta();
+        pickMeta.displayName(net.kyori.adventure.text.Component.text("Epic Pick"));
+        pick.setItemMeta(pickMeta);
+        // lore contains "legendary"
+        org.bukkit.inventory.ItemStack shovel = new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND_SHOVEL, 1);
+        org.bukkit.inventory.meta.ItemMeta shovelMeta = shovel.getItemMeta();
+        java.util.List<net.kyori.adventure.text.Component> lore = new java.util.ArrayList<>();
+        lore.add(net.kyori.adventure.text.Component.text("A legendary tool"));
+        shovelMeta.lore(lore);
+        shovel.setItemMeta(shovelMeta);
+
+        om.createSellOrder(UUID.randomUUID(), sword, 10, 1);
+        om.createSellOrder(UUID.randomUUID(), pick, 20, 1);
+        om.createSellOrder(UUID.randomUUID(), shovel, 30, 1);
+
+        assertEquals(1, om.searchSellOrders("sword", 0, 45).size());
+        assertEquals(1, om.searchSellOrders("epic", 0, 45).size());
+        assertEquals(1, om.searchSellOrders("legendary", 0, 45).size());
+        assertEquals(0, om.searchSellOrders("nonexistent", 0, 45).size());
+        // null query behaves as empty (match none here due to pagination on empty query)
+        assertNotNull(om.searchSellOrders(null, 0, 45));
+    }
+
+    @Test
+    void testCategoryFilters() {
+        OrderManager om = new OrderManager();
+        om.createSellOrder(UUID.randomUUID(), new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND_SWORD, 1), 1, 1);
+        om.createSellOrder(UUID.randomUUID(), new org.bukkit.inventory.ItemStack(org.bukkit.Material.IRON_CHESTPLATE, 1), 1, 1);
+        om.createSellOrder(UUID.randomUUID(), new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIAMOND_PICKAXE, 1), 1, 1);
+        om.createSellOrder(UUID.randomUUID(), new org.bukkit.inventory.ItemStack(org.bukkit.Material.POTION, 1), 1, 1);
+        om.createSellOrder(UUID.randomUUID(), new org.bukkit.inventory.ItemStack(org.bukkit.Material.DIRT, 1), 1, 1);
+
+        assertEquals(1, om.filterSellOrdersByCategory(ItemTypeCategory.WEAPONS, 0, 45).size());
+        assertEquals(1, om.filterSellOrdersByCategory(ItemTypeCategory.ARMOR, 0, 45).size());
+        assertEquals(1, om.filterSellOrdersByCategory(ItemTypeCategory.TOOLS, 0, 45).size());
+        assertEquals(1, om.filterSellOrdersByCategory(ItemTypeCategory.POTIONS, 0, 45).size());
+        assertEquals(1, om.filterSellOrdersByCategory(ItemTypeCategory.MISC, 0, 45).size());
+    }
+
+    @Test
+    void testDeliveriesEnqueueDrainGetPageAndRemove() {
+        OrderManager om = new OrderManager();
+        UUID uid = UUID.randomUUID();
+        for (int i = 0; i < 100; i++) {
+            org.bukkit.inventory.ItemStack it = new org.bukkit.inventory.ItemStack(org.bukkit.Material.COBBLESTONE, i + 1);
+            om.enqueueDelivery(uid, it);
+        }
+        // getDeliveries clone
+        List<org.bukkit.inventory.ItemStack> snapshot = om.getDeliveries(uid);
+        assertEquals(100, snapshot.size());
+        // removeDeliveryAt bounds
+        assertNull(om.removeDeliveryAt(uid, -1));
+        assertNull(om.removeDeliveryAt(uid, 100));
+        // pagination
+        assertEquals(45, om.getDeliveriesPage(uid, 0, 45).size());
+        assertEquals(45, om.getDeliveriesPage(uid, 1, 45).size());
+        assertEquals(10, om.getDeliveriesPage(uid, 2, 45).size());
+        assertTrue(om.getDeliveriesPage(uid, 3, 45).isEmpty());
+        // remove actual item
+        org.bukkit.inventory.ItemStack removed = om.removeDeliveryAt(uid, 0);
+        assertNotNull(removed);
+        assertEquals(org.bukkit.Material.COBBLESTONE, removed.getType());
+        assertEquals(100 - 1, om.getDeliveries(uid).size());
+        // drain
+        List<org.bukkit.inventory.ItemStack> drained = om.drainDeliveries(uid);
+        assertEquals(99, drained.size());
+        assertTrue(om.getDeliveries(uid).isEmpty());
+    }
+
+    @Test
+    void testSaveLoadRoundtrip(@TempDir Path tempDir) throws Exception {
+        OrderManager om = new OrderManager();
+        UUID seller = UUID.randomUUID();
+        UUID buyer = UUID.randomUUID();
+        om.createSellOrder(seller, new org.bukkit.inventory.ItemStack(org.bukkit.Material.EMERALD, 12), 3, 12);
+        om.createBuyOrder(buyer, new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLD_INGOT, 7), 9, 7, 63);
+        om.enqueueDelivery(buyer, new org.bukkit.inventory.ItemStack(org.bukkit.Material.GOLD_INGOT, 3));
+
+        File file = tempDir.resolve("orders.yml").toFile();
+        om.save(file);
+
+        OrderManager loaded = new OrderManager();
+        loaded.load(file);
+
+        assertEquals(1, loaded.getSellOrders().size());
+        assertEquals(1, loaded.getBuyOrders().size());
+        assertEquals(1, loaded.getDeliveries(buyer).size());
+
+        SellOrder so = loaded.getSellOrders().get(0);
+        assertEquals(3, so.getPricePerUnit());
+        assertEquals(12, so.getAmount());
+        assertEquals(org.bukkit.Material.EMERALD, so.getItem().getType());
+
+        BuyOrder bo = loaded.getBuyOrders().get(0);
+        assertEquals(9, bo.getPricePerUnit());
+        assertEquals(7, bo.getAmount());
+        assertEquals(63, bo.getEscrowTotal());
+        assertEquals(org.bukkit.Material.GOLD_INGOT, bo.getTemplateItem().getType());
+    }
+}
+
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce GitHub Actions CI with coverage, add extensive JUnit/Mockito/MockBukkit tests, and make item save/load and command handling more robust.
> 
> - **Testing & CI**:
>   - Add GitHub Actions workflows: `CI` (PR/build, JaCoCo artifact, require-tests), `CI - Tests` (branch/manual), and `Create testing issue` automation.
>   - Maven: add JUnit 5, Mockito, MockBukkit; configure `surefire` and `jacoco` with coverage checks; cache Maven in CI.
> - **Build**:
>   - Update `paper-api` to `1.21.1-R0.1-SNAPSHOT`.
>   - `.gitignore`: ignore `.cursor/`.
> - **Core changes**:
>   - `OrderManager`: serialize `ItemStack` via `serialize()`; significantly more robust YAML load paths (maps, sections, fallback type/amount) for orders and `pendingDeliveries`; add minimal debug logging.
>   - `SellOrderCreateCommand`: treat all air variants as empty hand; small refactor.
>   - `TNAuctionHousePlugin`: remove `final` modifier.
> - **Tests**:
>   - Add lifecycle, command, model, and order manager tests (roundtrip/save-load, pagination, search, category filters, deliveries) using MockBukkit and a dummy Vault `Economy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5519094bcece60aa1f39d195cdb9d77829ced6e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->